### PR TITLE
Release v3.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: unless-stopped
 
   api:
-    build: .
+    image: ghcr.io/annurdien/idlix-api:latest
     container_name: idlix-api
     ports:
       - "3000:3000"


### PR DESCRIPTION
Prepare v3.0.0 release. Updated docker-compose.yml to use the published GHCR image.